### PR TITLE
Add nested modello feature

### DIFF
--- a/examples/nested_geometry.py
+++ b/examples/nested_geometry.py
@@ -1,0 +1,20 @@
+"""Example showing nested models.
+
+>>> box = Box("B", base={"a": 3, "b": 4}, height=12)
+>>> box.base.c
+5
+>>> box.diagonal
+13
+"""
+from modello import InstanceDummy, Modello
+from examples.geometry import RightAngleTriangle
+from sympy import sqrt
+
+
+class Box(Modello):
+    """Simple box using a RightAngleTriangle as the base."""
+
+    base = RightAngleTriangle
+    height = InstanceDummy("height", positive=True)
+    diagonal = sqrt(base.c ** 2 + height ** 2)
+

--- a/examples/nested_line.py
+++ b/examples/nested_line.py
@@ -1,0 +1,23 @@
+"""Example demonstrating nested models with a Line composed of Points.
+
+>>> line = Line("L", start={"x": 0, "y": 0}, end={"x": 3, "y": 4})
+>>> line.length
+5
+"""
+from modello import InstanceDummy, Modello
+from sympy import sqrt
+
+
+class Point(Modello):
+    """Simple 2D point."""
+
+    x = InstanceDummy("x", real=True)
+    y = InstanceDummy("y", real=True)
+
+
+class Line(Modello):
+    """Line consisting of two points."""
+
+    start = Point
+    end = Point
+    length = sqrt((end.x - start.x) ** 2 + (end.y - start.y) ** 2)

--- a/examples/streaming.py
+++ b/examples/streaming.py
@@ -59,6 +59,24 @@ class DoubleDataEntryFlow(ScalableFlow):
     unit_output = Rational(8 * 260, 24 * 365) / entry_time / 2
 
 
+class EntrySystem(Modello):
+    """Simple system demonstrating nesting of flows.
+
+    >>> sys = EntrySystem(
+    ...     "SYS",
+    ...     flow={"input": 20, "entry_time": 5, "unit_cost": Rational(1, 10), "scale": 2},
+    ...     overhead=1,
+    ... )
+    >>> sys.total_cost
+    6/5
+    """
+
+    flow = SingleDataEntryFlow
+    overhead = InstanceDummy("overhead", positive=True, rational=True)
+    total_cost = flow.cost + overhead
+
+
+
 def test_simple_system():
     """The wheels on the bus go round and round."""
     channel_input_rates = {"foo": 12, "bar": 3}

--- a/test_modello.py
+++ b/test_modello.py
@@ -38,3 +38,59 @@ def test_multiple_inheritance_expr_conflict():
 
     assert ExampleC.conflicted == ExampleB.conflicted
     assert ExampleC.conflicted != ExampleA.conflicted
+
+
+def test_nested_models_dict():
+    """Nested models accept dictionaries of values."""
+
+    class Child(Modello):
+        a = InstanceDummy("a")
+        b = InstanceDummy("b")
+        c = a + b
+
+    class Parent(Modello):
+        child = Child
+        d = InstanceDummy("d")
+        e = child.c + d
+
+    instance = Parent("P", child={"a": 3, "b": 4}, d=5)
+    assert instance.child.c == 7
+    assert instance.e == 12
+
+
+def test_nested_models_instance():
+    """Nested models accept pre-instantiated children."""
+
+    class Child(Modello):
+        a = InstanceDummy("a")
+        b = InstanceDummy("b")
+        c = a + b
+
+    child = Child("C", a=2, b=3)
+
+    class Parent(Modello):
+        child = Child
+        d = InstanceDummy("d")
+        e = child.c + d
+
+    instance = Parent("P", child=child, d=4)
+    assert instance.child.c == 5
+    assert instance.e == 9
+
+
+def test_nested_partial_values():
+    """Unspecified nested attributes are solved with the parent."""
+
+    class Child(Modello):
+        a = InstanceDummy("a")
+        b = InstanceDummy("b")
+        c = a + b
+
+    class Parent(Modello):
+        child = Child
+        c_total = child.c + 1
+
+    instance = Parent("P", child={"a": 2})
+    # b defaults to dummy but derived c should resolve using constraints
+    assert instance.child.c == instance.child.a + instance.child.b
+    assert instance.c_total == instance.child.c + 1

--- a/test_modello.py
+++ b/test_modello.py
@@ -94,3 +94,38 @@ def test_nested_partial_values():
     # b defaults to dummy but derived c should resolve using constraints
     assert instance.child.c == instance.child.a + instance.child.b
     assert instance.c_total == instance.child.c + 1
+
+
+def test_helper_parse_nested_values():
+    """_parse_nested_values splits nested data from values."""
+
+    class Child(Modello):
+        x = InstanceDummy("x")
+
+    class Parent(Modello):
+        child = Child
+        y = InstanceDummy("y")
+
+    instance = object.__new__(Parent)
+    values = {"child": {"x": 5}, "y": 3}
+    nested = instance._parse_nested_values(values)
+    assert nested == {"child": {"x": 5}}
+    assert values == {"y": 3}
+
+
+def test_helper_create_instance_dummies():
+    """_create_instance_dummies binds dummies for the instance."""
+
+    class Child(Modello):
+        x = InstanceDummy("x")
+
+    class Parent(Modello):
+        child = Child
+        y = InstanceDummy("y")
+
+    instance = object.__new__(Parent)
+    dummies, nested = instance._create_instance_dummies("X")
+    assert dummies[Parent._modello_namespace.dummies["y"]].name.startswith("X_")
+    child_dummy = Child._modello_namespace.dummies["x"]
+    assert child_dummy in nested["child"]
+    assert nested["child"][child_dummy].name.startswith("X_")

--- a/test_modello.py
+++ b/test_modello.py
@@ -106,11 +106,10 @@ def test_helper_parse_nested_values():
         child = Child
         y = InstanceDummy("y")
 
-    instance = object.__new__(Parent)
     values = {"child": {"x": 5}, "y": 3}
-    nested = instance._parse_nested_values(values)
+    nested, remaining = Parent._parse_nested_values(values)
     assert nested == {"child": {"x": 5}}
-    assert values == {"y": 3}
+    assert remaining == {"y": 3}
 
 
 def test_helper_create_instance_dummies():
@@ -123,9 +122,74 @@ def test_helper_create_instance_dummies():
         child = Child
         y = InstanceDummy("y")
 
-    instance = object.__new__(Parent)
-    dummies, nested = instance._create_instance_dummies("X")
+    dummies, nested = Parent._create_instance_dummies("X")
     assert dummies[Parent._modello_namespace.dummies["y"]].name.startswith("X_")
     child_dummy = Child._modello_namespace.dummies["x"]
     assert child_dummy in nested["child"]
     assert nested["child"][child_dummy].name.startswith("X_")
+
+
+def test_helper_collect_instance_constraints():
+    """_collect_instance_constraints handles nested dictionaries."""
+
+    class Child(Modello):
+        a = InstanceDummy("a")
+        b = InstanceDummy("b")
+
+    class Parent(Modello):
+        child = Child
+        c = InstanceDummy("c")
+
+    dummies, nested_map = Parent._create_instance_dummies("P")
+    constraints = Parent._collect_instance_constraints(
+        {"c": 4}, {"child": {"a": 1}}, dummies
+    )
+    assert constraints[dummies[Parent._modello_namespace.dummies["c"]]] == 4
+    child_dummy = Child._modello_namespace.dummies["a"]
+    proxy_dummy = nested_map["child"][child_dummy]
+    assert constraints[proxy_dummy] == 1
+
+
+def test_meta_setitem_creates_proxy():
+    """Assigning a model class creates proxy dummies."""
+
+    class Child(Modello):
+        x = InstanceDummy("x")
+
+    class Parent(Modello):
+        child = Child
+
+    proxy = Parent._modello_namespace.other_attrs["child"]
+    assert type(proxy).__name__ == "ChildProxy"
+    assert Parent._modello_namespace.nested_models["child"][0] is Child
+    for dummy in Child._modello_namespace.dummies.values():
+        proxy_dummy = Parent._modello_namespace.nested_models["child"][1][dummy]
+        assert getattr(proxy, dummy.name) is proxy_dummy
+
+
+def test_nested_multiple_levels():
+    """Nested models work across more than one level."""
+
+    class Leaf(Modello):
+        a = InstanceDummy("a")
+        b = InstanceDummy("b")
+        total = a + b
+
+    class Branch(Modello):
+        leaf = Leaf
+        offset = InstanceDummy("offset")
+        total = leaf.total + offset
+
+    class Tree(Modello):
+        left = Branch
+        right = Branch
+        whole = left.total + right.total
+
+    left = Branch("L", leaf={"a": 1, "b": 2}, offset=1)
+    right = Branch("R", leaf={"a": 2, "b": 3}, offset=2)
+    tree = Tree("T", left=left, right=right)
+    assert tree.left.leaf.total == 3
+    assert tree.left.total == 4
+    assert tree.right.leaf.total == 5
+    assert tree.right.total == 7
+    assert tree.whole == 11


### PR DESCRIPTION
## Summary
- add nested model handling to `Modello`
- create `examples/nested_line.py` demonstrating nested usage
- support nested models in tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6852f6134d60832286add272ded95757